### PR TITLE
Guardfileのklassに改行コードが入らないように修正

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -21,7 +21,7 @@ def generate_rdoc(rd_path)
   method = BitClust::MethodSignature.parse(method).name if method
   klass = prev.reverse_each.detect do |line|
     next unless line.start_with?('= ')
-    m = line.match(/^= (?:class|module) ([^ ]+) ?/)
+    m = line.match(/^= (?:class|module) ([^ \n]+) ?/)
     break m && m[1]
   end
   target = prev.reverse_each.detect do |line|


### PR DESCRIPTION
FileTestの例で
```
module FileTest

ファイルの検査関数を集めたモジュールです。
```
といった継承なしのモジュールの場合、klassに改行コードを含んでしまうため、正規表現を修正しました。
```ruby
# before: 
klass # => "FileTest\n"

# after:
klass # => "FileTest"
```